### PR TITLE
Fixes type warnings

### DIFF
--- a/binny.c
+++ b/binny.c
@@ -392,7 +392,7 @@ void handleInput(int c)
                 return;
             }
             resizeBuffer(strtol(userInput, NULL, 0));
-            sprintf(userOutput, "Buffer resized to 0x%X / %d", bufferLength, bufferLength);
+            sprintf(userOutput, "Buffer resized to 0x%lX / %ld", bufferLength, bufferLength);
             bufferModified = 1;
         }
         else if (c == 'G')
@@ -968,7 +968,7 @@ void inputPopup(char * title)
     wrefresh(popupWin);
 
     echo();
-    getnstr(&userInput, POPUP_WIDTH - 2);
+    getnstr(userInput, POPUP_WIDTH - 2);
     noecho();
 }
 


### PR DESCRIPTION
The warnings I saw are:

```
% make
gcc -o binny -lncurses binny.c
binny.c: In function 'handleInput':
binny.c:395:13: warning: format '%X' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat]
binny.c:395:13: warning: format '%d' expects argument of type 'int', but argument 4 has type 'long unsigned int' [-Wformat]
binny.c: In function 'inputPopup':
binny.c:971:5: warning: passing argument 2 of 'wgetnstr' from incompatible pointer type [enabled by default]
In file included from binny.c:7:0:
/usr/include/ncurses.h:793:28: note: expected 'char *' but argument is of type 'char (*)[255]'
```

With the modifications, GCC (4.7.3) would output no warnings.
